### PR TITLE
Type Error: __init__() got an unexpected keyword argument 'estimator'

### DIFF
--- a/honest_forests/estimators/forest.py
+++ b/honest_forests/estimators/forest.py
@@ -331,7 +331,7 @@ class HonestForestClassifier(ForestClassifier):
         honest_prior="empirical",
     ):
         super().__init__(
-            estimator=HonestTreeClassifier(),
+            base_estimator=HonestTreeClassifier(),
             n_estimators=n_estimators,
             estimator_params=(
                 "honest_fraction",


### PR DESCRIPTION
Here is an error shows about Type Error:__init__() got an unexpected keyword argument 'estimator', When install the merged one. "estimator" is added at forest.py, where estimator=HonestTreeClassifier(), which replaces the base_estimator in pervious version. Solved now by checking code of"sklearn.ensemble._forest" and changing back to base_estimator. 
For reference: https://scikit-optimize.github.io/stable/_modules/sklearn/ensemble/_forest.html